### PR TITLE
Avoid having to restart the replayer and the server once all events have been replayed

### DIFF
--- a/libs/clean_db.sh
+++ b/libs/clean_db.sh
@@ -1,0 +1,5 @@
+docker volume rm $(docker volume ls -qf dangling=true)
+docker rm -f some-mongo some-redis
+docker run --name some-mongo -d -p 27017:27017 mongo
+docker run --name some-redis -d -p 6379:6379 redis redis-server --appendonly yes
+touch ~/git/nirdizati-runtime/test.txt


### PR DESCRIPTION
I think this is a cleaner solution on what to do when the replayer has finished replaying all the events. I understand that in practice when we deal with potentially unbounded **event streams**, we will never "run out" of events, so this problem of having to restart the replayer will probably become irrelevant. Nevertheless, to make the runtime component work better on **event logs**, I propose this change